### PR TITLE
ServiceResponse class added.

### DIFF
--- a/src/helpers/ServiceResponse/index.js
+++ b/src/helpers/ServiceResponse/index.js
@@ -1,20 +1,12 @@
 class ServiceResponse {
     succeeded = false;
     message = '';
-    model = {};
+    model = null;
 
-    constructor(succeeded, message, model) {
-        this.succeeded = succeeded;
-        this.message = message;
-        this.model = model;
-    }
-
-    static ResultServiceResponse(succeeded) {
-        return new ServiceResponse(succeeded, '', {});
-    }
-
-    static ResultAndMessageServiceResponse(succeeded, message) {
-        return new ServiceResponse(succeeded, message, {});
+    constructor( { succeeded, message, model } ) {
+        this.succeeded = succeeded || succeeded;
+        this.message = message || this.message;
+        this.model = model || this.model;
     }
 }
 

--- a/src/helpers/ServiceResponse/index.js
+++ b/src/helpers/ServiceResponse/index.js
@@ -1,0 +1,21 @@
+class ServiceResponse {
+    succeeded = false;
+    message = '';
+    model = {};
+
+    constructor(succeeded, message, model) {
+        this.succeeded = succeeded;
+        this.message = message;
+        this.model = model;
+    }
+
+    static ResultServiceResponse(succeeded) {
+        return new ServiceResponse(succeeded, '', {});
+    }
+
+    static ResultAndMessageServiceResponse(succeeded, message) {
+        return new ServiceResponse(succeeded, message, {});
+    }
+}
+
+module.exports = ServiceResponse;


### PR DESCRIPTION
Этот класс предназначен для ответов сервисов. Сервисы будут возвращать экземпляры класса `ServiceResponse`, передавая в него необходимые параметры.

`succeeded` = `true/false` - сообщает о результате выполнения сервиса;
`message `= `''` - дополнительное сообщение, туда можно передать причину ошибки. Если `succeeded === true`, то в `message `можно ничего не класть;
`model `= `{}` - сюда передается модель ответа. Это могут быть сущности при гет запросе. Если такая модель не нужна, то ничего не передаём;

Пример использования (сервис пользователя):
```
    async create(telegramId) {
        try {
            const result = await User.findOrCreate({
                where: {
                    telegramId: telegramId
                },
                defaults: {
                    telegramId: telegramId
                }
            });
            const created = result[1];

            if (!created)
                return new ServiceResponse( { succeeded: true} );

            return new ServiceResponse ( { succeeded: true, message: `User with such telegramId already exists.` } );
        } catch (e) {
            return new ServiceResponse ( { succeeded: false, message: `Error occurred while creating user with telegramId=${telegramId}` } )
        }
    }
```