### PR TITLE
'telegramId' and 'localName' composite unique index.

### DIFF
--- a/src/database/migrations/20201120183426-add-telegramId-localName-uniqueness.js
+++ b/src/database/migrations/20201120183426-add-telegramId-localName-uniqueness.js
@@ -1,0 +1,19 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addConstraint(
+      'Locations',
+      {
+        fields: ['telegramId', 'localName'],
+        type: 'unique',
+        name: 'telegramIdAndLocalnameUnique',
+      },
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeConstraint(
+      'Locations',
+      'telegramIdAndLocalnameUnique',
+    );
+  },
+};

--- a/src/database/models/location.js
+++ b/src/database/models/location.js
@@ -22,6 +22,7 @@ module.exports = (sequelize, DataTypes) => {
     telegramId: {
       allowNull: false,
       type: DataTypes.INTEGER,
+      unique: 'telegramIdAndLocalnameUnique',
       references: {
         model: 'Users',
         key: 'telegramId'
@@ -33,7 +34,8 @@ module.exports = (sequelize, DataTypes) => {
     },
     localName: {
       allowNull: false,
-      type: DataTypes.STRING
+      type: DataTypes.STRING,
+      unique: 'telegramIdAndLocalnameUnique',
     },
     globalName: {
       allowNull: false,


### PR DESCRIPTION
Пользователю нельзя давать возможность **одинаково называть свои локации,** поэтому была создана миграция, которая добавляет уникальный композитный ключ на колонки `telegramId` и `localName` таблицы `Locations`.