### PR TITLE
Correct paths were set in '.sequelizers'.

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
   'config': path.resolve(__dirname, 'src', 'configs', 'sequelize.config.js'),
-  'models-path': path.resolve(__dirname,  'src', 'dataBase', 'models'),
-  'seeders-path': path.resolve(__dirname, 'src', 'dataBase', 'seeders'),
-  'migrations-path': path.resolve(__dirname, 'src', 'dataBase', 'migrations')
+  'models-path': path.resolve(__dirname,  'src', 'database', 'models'),
+  'seeders-path': path.resolve(__dirname, 'src', 'database', 'seeders'),
+  'migrations-path': path.resolve(__dirname, 'src', 'database', 'migrations')
 };


### PR DESCRIPTION
Указал корректные пути к миграциям, моделям и сидам в `.sequelizers`.